### PR TITLE
Added Logic to the Extension Enable and DIsable Button

### DIFF
--- a/controllers/background.js
+++ b/controllers/background.js
@@ -215,6 +215,8 @@ function update_mastery(vocab, mastered){
 if (localStorage['lastVersionUsed'] != '1') {
 	localStorage['lastVersionUsed'] = '1';
 	initialize_indexedDB();
+	//Set the extention to be enabled
+	chrome.storage.sync.set({extensionEnabled: true});
 	chrome.tabs.create({
 		url: chrome.extension.getURL('views/welcome.html')
 	});

--- a/controllers/content_script.js
+++ b/controllers/content_script.js
@@ -1,4 +1,5 @@
-
+//Variable used to turn on debug mode
+var debug = false;
 var bubbleDiv = null;
 
 //This funciton will be called when users select the text. It will handle false alarms when users just simply click and selects nothing. 
@@ -25,8 +26,12 @@ function textSelection() {
   //Only trigger text look up if there are words selected
   if(selectedText != "" && selectedText != '' && bubbleDiv == null){
     var info = getSelectionInfo();
-    bubbleDiv = createDiv(info, selectedText);
-    wordLookup(selectedText);
+    chrome.storage.sync.get('extensionEnabled', function(result) {
+      if (result.extensionEnabled){ 
+        bubbleDiv = createDiv(info, selectedText);
+        wordLookup(selectedText);
+      }
+    });
   }
   else{
     //Code to dimiss the pop up bubble
@@ -96,7 +101,7 @@ function appendToDiv(content){
     let data;
     //add text for user to click link to the source of the definition
     bubbleDiv.moreInfo.textContent = "More »"; 
-    console.log("word :" + word);
+    debug && console.log("word :" + word);
 
     chrome.runtime.sendMessage({vocab:word, definition:definition});
   }
@@ -256,5 +261,5 @@ function createDiv(info, selectedText) {
 
 //The event that will trigger the textSelection function which will process the selected vocabularies. 
 document.onclick = function() {
-  textSelection();
+  textSelection();    
 };

--- a/controllers/popup.js
+++ b/controllers/popup.js
@@ -1,0 +1,49 @@
+chrome.storage.sync.get('extensionEnabled', function(result) {
+	let btnOn = document.getElementById("btnOn");
+	let btnOff = document.getElementById("btnOff");
+	let labelOn = document.getElementById("label-on");
+	let labelOff = document.getElementById("label-off");
+	console.log(result.extensionEnabled);
+	if (result.extensionEnabled){
+		btnOn.checked = true;
+		btnOff.checked = false;
+		labelOn.className = "btn btn-primary active";
+		labelOff.className = "btn btn-outline-danger";
+	}
+	else{
+		btnOn.checked = false;
+		btnOff.checked = true;
+		labelOn.className = "btn btn-outline-primary";
+		labelOff.className = "btn btn-danger active";
+	}
+});
+
+document.getElementById("btnOn").addEventListener("click", toggleHandler);
+document.getElementById("btnOff").addEventListener("click", toggleHandler);
+
+function toggleHandler(e) {
+	let source = e.srcElement || e.originalTarget;
+	console.log(source.id);
+	let btnOn = document.getElementById("btnOn");
+	let btnOff = document.getElementById("btnOff");
+	let labelOn = document.getElementById("label-on");
+	let labelOff = document.getElementById("label-off");
+	if(source.id == "btnOn") {
+		chrome.storage.sync.set({extensionEnabled: true});
+		labelOn.className = "btn btn-primary focus active";
+		labelOff.className = "btn btn-outline-danger";	
+		btnOn.checked = false;
+		btnOff.checked = true;
+		console.log("btnOn");
+	}
+	else if(source.id == "btnOff") {
+		chrome.storage.sync.set({extensionEnabled: false});
+		labelOn.className = "btn btn-outline-primary";
+		labelOff.className = "btn btn-danger focus active";
+		btnOn.checked = true;
+		btnOff.checked = false;
+		console.log("btnOff");
+	}
+	console.log("btnOn : "+btnOn.checked);
+	console.log("btnOff : "+btnOff.checked);
+}

--- a/manifest.json
+++ b/manifest.json
@@ -49,6 +49,7 @@
     "permissions": [
     	"alarms",
     	"notifications",
-    	"tabs"
+    	"tabs",
+    	"storage"
     ]
 }

--- a/views/popup.html
+++ b/views/popup.html
@@ -17,12 +17,12 @@
 		<div class="container">
 			<div class="row justify-content-center">
 				Toggle Dictionary:
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<label class="btn btn-outline-primary active">
-						<input type="radio" name="options" id="option-on" checked> On
+				<div class="btn-group btn-group-toggle">
+					<label class="btn btn-outline-primary" id="label-on">
+						<input type="radio" autocomplete="off" id="btnOn"> On
 					</label>
-					<label class="btn btn-outline-danger">
-						<input type="radio" name="options" id="option-off"> Off
+					<label class="btn btn-outline-danger" id="label-off">
+						<input type="radio" autocomplete="off" id="btnOff"> Off
 					</label>
 				</div>
 			</div>
@@ -35,5 +35,6 @@
 		</div>
 	    <script src="bootstrap-4.4.1/js/jquery-3.4.1.slim.min.js"></script>
 	    <script src="bootstrap-4.4.1/js/bootstrap.bundle.min.js"></script>
+	    <script src="../controllers/popup.js"></script>
 	</body>
 </html>

--- a/views/word-list.html
+++ b/views/word-list.html
@@ -16,7 +16,7 @@
 			</a>
 			<input class="form-control mr-sm-2 mt-2" id="vocabSearch" type="search" placeholder="Search" aria-label="Search">
 		</nav>
-		<div class="btn-group-toggle ml-3 mt-2" data-toggle="buttons" id="statusFilter" aria-label="Basic example">
+		<div class="btn-group-toggle ml-3 mt-2" data-toggle="buttons" id="statusFilter">
   				<label class="btn btn-outline-danger btn-sm active">
   					<input type="checkbox" autocomplete="off">New
   				</label>


### PR DESCRIPTION
1. background.js
- Added instruction to enable the extension in the sync storage. 
2. content_script.js
- I've added the logic to enable and disable the logic according to the extensionEnabled flag. 
3. popup.js
- A new script that contains the logic of retrieving and storing the extensionEnabled flag and the manipulation of the UI. 
4. mnifest.json
- Added storage permission
5. popup.html
- Included popup.js's path
- Added ids and removed unnecessary logic. 
6. word-list.html
- Removed unneeded label.